### PR TITLE
Closes #51 Add entries for site-admins to delete users and organizations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ organizations as well as member/admin control for those organizations.
 For instructions on webgme authentication and user-management see [this demo on youtube](https://www.youtube.com/watch?v=xS6_FK8kZhE).
 
 ##Developers
-####Steps to run as an external REST component within WebGME
+####Steps to run as an external REST router within WebGME
 
 WebGME requires [NodeJS](https://nodejs.org/) (0.12 <= version, CI tests are performed on versions 4.x, 6.x) and [MongoDB](https://www.mongodb.com/) (version >= 2.6) installed on the host system (the server).
 In addition the npm installation requires [Git](https://git-scm.com) to be installed and available in PATH.
@@ -20,3 +20,14 @@ In addition the npm installation requires [Git](https://git-scm.com) to be insta
 3. Run webpack `npm run webpack`
 4. Start (webgme) server `npm start`
 5. From a browser visit `http://localhost:8888/usermanagement/`
+
+
+####Webpack file listener
+To build client side bundle on file changes invoke
+```
+webpack -w
+```
+or if not installed globally
+```
+npm run webpack -- -w
+```

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -7,7 +7,7 @@ var config = require('webgme/config/config.default'),
     path = require('path');
 
 config.server.port = 8888;
-config.mongo.uri = 'mongodb://127.0.0.1:27017/example';
+config.mongo.uri = 'mongodb://127.0.0.1:27017/multi';
 
 config.authentication.enable = true;
 config.authentication.allowGuests = false;

--- a/src/client/style/index.js
+++ b/src/client/style/index.js
@@ -205,6 +205,10 @@ export const ProfileBox = {
     },
     updateButton: {
         float: "right"
+    },
+    deleteButton: {
+        float: "left",
+        tabindex: "-1"
     }
 };
 

--- a/src/common/components/content/pages/OrganizationPage.jsx
+++ b/src/common/components/content/pages/OrganizationPage.jsx
@@ -30,10 +30,17 @@ export default class OrganizationPage extends Component {
     }
 
     render() {
-        const {basePath, canAuthorize} = this.props;
+        const {basePath, canAuthorize, organizationExists} = this.props;
+
+        if (!organizationExists) {
+            return (<section className="content">
+                <Link to={`${this.props.basePath}organizations`}>
+                    {`No such organization '${this.props.params.organizationId}', back to organizations ...`}
+                </Link>
+            </section>);
+        }
 
         return (
-
             <section className="content">
                 <div className="box box-primary" style={PROJECT_STYLE.titleBox}>
                     <div className="row">
@@ -80,7 +87,6 @@ export default class OrganizationPage extends Component {
             </section>
         );
     }
-
 }
 
 OrganizationPage.propTypes = {

--- a/src/common/components/content/widgets/ProfileBox.jsx
+++ b/src/common/components/content/widgets/ProfileBox.jsx
@@ -261,9 +261,7 @@ export default class ProfileBox extends Component {
         const {editable, user, config, isCurrentUser} = this.props;
         let isGuest = user._id === config.authentication.guestAccount,
             nbrOfOwnedProjects = Object.keys(user.projects).filter(function(projectId) {
-                console.log(projectId);
-                console.log(projectId.split('+')[0]);
-                console.log(user._id);
+                // FIXME: Do not rely on split
                 return projectId.split('+')[0] === user._id;
             }).length;
 

--- a/src/common/components/content/widgets/ProfileBox.jsx
+++ b/src/common/components/content/widgets/ProfileBox.jsx
@@ -5,7 +5,7 @@
 
 // Libraries
 import React, {Component, PropTypes} from 'react';
-import {Button, ButtonGroup} from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
 // Self-defined
 import LoginField from '../../../components/content/widgets/LoginField';
 import {fetchUser} from '../../../actions/user';
@@ -365,7 +365,7 @@ export default class ProfileBox extends Component {
                             <Button bsStyle="danger"
                                     onClick={this.showModal}
                                     style={STYLE.deleteButton}>
-                                Delete
+                                Delete ...
                             </Button> : null}
 
                         {editable && this.state.hasEdits ?
@@ -387,7 +387,7 @@ export default class ProfileBox extends Component {
                              confirmId={user._id}
                              modalMessage={'Are you sure you want to delete ' + user._id + '? This user owns ' +
                                nbrOfOwnedProjects + ' project(s).' + (nbrOfOwnedProjects > 0 ?
-                                 ' Check projects table filtered by user for full list. ' : ' ') +
+                                 ' Check projects table filtered by owner for full list. ' : ' ') +
                                  'Deleted users still reside in the database with the extra property "disabled: true"' +
                                  ' and can be recovered manually.'
                              }

--- a/src/common/containers/content/pages/OrganizationPage.jsx
+++ b/src/common/containers/content/pages/OrganizationPage.jsx
@@ -22,10 +22,20 @@ const mapStateToProps = (state, ownProps) => {
         return project.owner === organizationId;
     });
 
+    let organizationExists = false;
+    let organization = organizations.find((org) => {
+        return org._id === organizationId;
+    });
+
+    if (organization) {
+        organizationExists = true;
+    }
+
     return {
         basePath,
         canAuthorize,
-        ownedProjects
+        ownedProjects,
+        organizationExists
     };
 };
 

--- a/src/common/containers/content/pages/OrganizationPage.jsx
+++ b/src/common/containers/content/pages/OrganizationPage.jsx
@@ -35,7 +35,8 @@ const mapStateToProps = (state, ownProps) => {
         basePath,
         canAuthorize,
         ownedProjects,
-        organizationExists
+        organizationExists,
+        user
     };
 };
 


### PR DESCRIPTION
Keep in mind that deleted users/orgs still exist in the database holding up that id. You can manually recover the deleted entity by modifying the disabled property under _users in the mongo database (organization live here too).

