### PR TITLE
Guard against cross-origin issue when digging out referrer from iframe

### DIFF
--- a/src/common/components/App.jsx
+++ b/src/common/components/App.jsx
@@ -19,7 +19,11 @@ export default class App extends Component {
         // Set the referrer in the session store (if not already set)
         if (typeof window.sessionStorage.getItem('originalReferrer') !== 'string') {
             // Use top in case embedded in iframe.
-            window.sessionStorage.setItem('originalReferrer', window.top.document.referrer);
+            try {
+                window.sessionStorage.setItem('originalReferrer', window.top.document.referrer);
+            } catch (e) {
+                // We're in a cross-referenced iframe.
+            }
         }
     }
 

--- a/src/common/components/login/app.jsx
+++ b/src/common/components/login/app.jsx
@@ -15,7 +15,11 @@ export default class App extends Component {
 
         if (typeof window.sessionStorage.getItem('originalReferrer') !== 'string') {
             // Use top in case embedded in iframe.
-            window.sessionStorage.setItem('originalReferrer', window.top.document.referrer);
+            try {
+                window.sessionStorage.setItem('originalReferrer', window.top.document.referrer);
+            } catch (e) {
+                // We're in a cross-referenced iframe.
+            }
         }
     }
 


### PR DESCRIPTION
Catch exceptions thrown when trying to dig out top referrer, in these cases it will fall back to the default logOutUrl.

This is related to 