### PR TITLE
Fixes #79 Add first cut on status page and update babel features

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
- "presets": [ "react", "es2015" ]
+ "presets": [ "react", "es2015" ],
+ "plugins": ["transform-class-properties"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,13 +4,7 @@
     "google",
     "plugin:react/recommended"
   ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 6,
-    "sourceType": "module"
-  },
+  "parser": "babel-eslint",
   "plugins": [
     "react"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,199 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.5.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.5.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -614,6 +807,28 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+      "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -816,6 +1031,12 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -827,6 +1048,18 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
   "devDependencies": {
     "admin-lte": "2.4.2",
     "babel-core": "^6.8.0",
+    "babel-eslint": "^8.2.3",
     "babel-istanbul": "^0.12.2",
     "babel-loader": "^7.1.4",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "blockies": "0.0.2",

--- a/src/client/rest_client/restClient.js
+++ b/src/client/rest_client/restClient.js
@@ -18,6 +18,14 @@ function RestClient(baseUrl = '/api/') {
     this.projects = new ProjectsClient(baseUrl);
     this.user = new UserClient(baseUrl);
     this.users = new UsersClient(baseUrl);
+
+    /**
+     * Gets the current user
+     * @return {Promise} //TODO: How to document the resolved value.
+     */
+    this.getStatus = () => {
+        return this.user.get(['status']);
+    };
 }
 
 module.exports = RestClient;

--- a/src/common/components/App.jsx
+++ b/src/common/components/App.jsx
@@ -7,7 +7,7 @@
 // Libraries
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {Route} from 'react-router-dom';
+import {Route, Redirect} from 'react-router-dom';
 // Self-defined
 import Footer from './footer/Footer';
 import Header from './header/Header';
@@ -22,6 +22,7 @@ import ProjectsPage from '../../common/containers/content/pages/ProjectsPage';
 import UserPage from '../../common/containers/content/pages/UserPage';
 import UsersPage from '../../common/containers/content/pages/UsersPage';
 import NewUserPage from '../../common/containers/content/pages/NewUserPage';
+import StatusPage from '../../common/containers/content/pages/StatusPage';
 
 export default class App extends Component {
 
@@ -35,7 +36,7 @@ export default class App extends Component {
     }
 
     render() {
-        const {themeColor, basePath} = this.props;
+        const {themeColor, siteAdmin, basePath} = this.props;
         const {pathname} = this.props.location;
         const {restClient} = this;
 
@@ -48,13 +49,13 @@ export default class App extends Component {
                     pathname={pathname}
                 />
 
-                <SideBar pathname={pathname}/>
+                <SideBar pathname={pathname} siteAdmin={siteAdmin}/>
                 <div className="content-wrapper">
                     <section className="content-header"/>
                     <Route
                         exact
                         path={`${basePath}`}
-                        render={() => (<HomePage pathname={pathname} restClient={restClient}/>)
+                        render={() => (<Redirect to={`${basePath}home`}/>)
                         }
                     />
                     <Route
@@ -127,6 +128,13 @@ export default class App extends Component {
                         render={() => (<NewUserPage pathname={pathname} restClient={restClient}/>)
                         }
                     />
+
+                    <Route
+                        exact
+                        path={`${basePath}status`}
+                        render={() => (<StatusPage pathname={pathname} restClient={restClient}/>)
+                        }
+                    />
                 </div>
                 <Footer/>
             </div>
@@ -136,5 +144,6 @@ export default class App extends Component {
 }
 
 App.propTypes = {
-    themeColor: PropTypes.string.isRequired
+    themeColor: PropTypes.string.isRequired,
+    siteAdmin: PropTypes.bool
 };

--- a/src/common/components/content/pages/StatusPage.jsx
+++ b/src/common/components/content/pages/StatusPage.jsx
@@ -1,6 +1,6 @@
 /**
  * Home page container
- * @author patrickkerrypei / https://github.com/patrickkerrypei
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 // Libraries

--- a/src/common/components/content/pages/StatusPage.jsx
+++ b/src/common/components/content/pages/StatusPage.jsx
@@ -1,0 +1,127 @@
+/**
+ * Home page container
+ * @author patrickkerrypei / https://github.com/patrickkerrypei
+ */
+
+// Libraries
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Button} from 'react-bootstrap';
+
+// Self-defined
+import {fetchUserIfNeeded} from '../../../actions/user';
+import {fetchUsersIfNeeded} from '../../../actions/users';
+
+const REFRESH_INTERVAL = 2000;
+
+export default class StatusPage extends Component {
+
+    constructor(props) {
+        super(props);
+        this.intervalId = null;
+    }
+
+    state = {
+        status: null,
+        auto: false
+    };
+
+    componentDidMount() {
+        const {dispatch} = this.props;
+
+        dispatch(fetchUserIfNeeded());
+        dispatch(fetchUsersIfNeeded());
+
+        this.updateStatus();
+    }
+
+    componentWillReceiveProps(newProps) {
+        if (this.props.user.siteAdmin !== newProps.user.siteAdmin) {
+            this.updateStatus(newProps.user.siteAdmin);
+        }
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.intervalId);
+    }
+
+    updateStatus = (force) => {
+        const {user, restClient} = this.props;
+        if (!user.siteAdmin && !force) {
+            return;
+        }
+
+        restClient.getStatus()
+            .then((status) => this.setState({status}))
+            .catch((err) => {
+                console.error(err);
+            });
+    };
+
+    toggleAuto = () => {
+        const {auto} = this.state;
+        if (auto) {
+            clearInterval(this.intervalId);
+        } else {
+            setInterval(() => {
+                this.updateStatus();
+            }, REFRESH_INTERVAL);
+        }
+
+        this.setState({auto: !auto});
+    };
+
+    render() {
+        const {status, auto} = this.state;
+
+        if (!status) {
+            return <section className="content"/>;
+        }
+
+        const listed = [];
+        Object.keys(status).forEach((key) => {
+            if (!status[key]) {
+                return;
+            }
+
+            listed.push((
+                <div key={key}>
+                    <h3> {key} </h3>
+                    <pre>
+                        {JSON.stringify(status[key], null, 2)}
+                    </pre>
+                </div>
+            ));
+        });
+
+        return (
+            <section className="content">
+                <span>
+                    <Button
+                        className="pull-right"
+                        onClick={this.updateStatus}
+                        disabled={auto}
+                    >
+                        Refresh
+                    </Button>
+
+                    <Button
+                        className="pull-right"
+                        onClick={this.toggleAuto}
+                    >
+                        {`${auto ? 'Dis' : 'En'}able auto refresh`}
+                    </Button>
+                </span>
+                {listed}
+            </section>
+        );
+    }
+
+}
+
+StatusPage.propTypes = {
+    basePath: PropTypes.string.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    user: PropTypes.object.isRequired,
+    restClient: PropTypes.object.isRequired
+};

--- a/src/common/components/content/widgets/data_tables/table_entries/ProjectsDataTableEntry.jsx
+++ b/src/common/components/content/widgets/data_tables/table_entries/ProjectsDataTableEntry.jsx
@@ -10,13 +10,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
-import PrettyLink from '../../../../utils/PrettyLink';
 
 // Self-defined
 import { fetchUserIfNeeded } from '../../../../../actions/user';
 import { timeAgo } from '../../../../../../client/utils/utils';
 import { DEFAULT_ISODATE } from '../../../../../../client/utils/constants';
 import {getUserDisplayName} from '../../../../../../client/utils/usersUtils';
+import PrettyLink from '../../../../utils/PrettyLink';
 
 export default class ProjectsDataTableEntry extends Component {
 

--- a/src/common/components/sidebar/SideBar.jsx
+++ b/src/common/components/sidebar/SideBar.jsx
@@ -8,11 +8,12 @@ import React, { Component } from 'react';
 // Self-defined components
 import SideBarMenu from '../../containers/sidebar/SideBarMenu';
 import SideBarUserPanel from '../../containers/sidebar/SideBarUserPanel';
+import PropTypes from "prop-types";
 
 export default class SideBar extends Component {
 
     render() {
-        const { pathname } = this.props;
+        const { pathname, siteAdmin } = this.props;
 
         return (
             <aside className="main-sidebar">
@@ -21,7 +22,7 @@ export default class SideBar extends Component {
 
                     <SideBarUserPanel/>
 
-                    <SideBarMenu pathname={pathname} />
+                    <SideBarMenu pathname={pathname} siteAdmin={siteAdmin}/>
 
                 </section>
 
@@ -30,3 +31,8 @@ export default class SideBar extends Component {
     }
 
 }
+
+SideBar.propTypes = {
+    pathname: PropTypes.string.isRequired,
+    siteAdmin: PropTypes.bool
+};

--- a/src/common/components/sidebar/SideBarMenu.jsx
+++ b/src/common/components/sidebar/SideBarMenu.jsx
@@ -4,16 +4,16 @@
  */
 
 // Libraries
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 // Style
-import { SideBarMenu as STYLE } from '../../../client/style';
+import {SideBarMenu as STYLE} from '../../../client/style';
 
 export default class SideBarMenu extends Component {
 
     render() {
-        const { basePath, pathname } = this.props;
+        const {basePath, pathname, siteAdmin} = this.props;
 
         return (
             <ul className="sidebar-menu" style={STYLE.sidebarCategoryStyle}>
@@ -50,6 +50,13 @@ export default class SideBarMenu extends Component {
                     </Link>
                 </li>
 
+                {siteAdmin ? (
+                    <li className={/status$/.test(pathname) ? 'active' : ''}>
+                        <Link to={`${basePath}status`} style={{textDecoration: "none"}}>
+                            <i className="fa fa-graduation-cap"/><span>Server Status</span>
+                        </Link>
+                    </li>) : null}
+
                 {/*
             <li className="treeview">
                 <a href="#">
@@ -69,5 +76,6 @@ export default class SideBarMenu extends Component {
 }
 
 SideBarMenu.propTypes = {
-    basePath: PropTypes.string.isRequired
+    basePath: PropTypes.string.isRequired,
+    siteAdmin: PropTypes.bool
 };

--- a/src/common/components/utils/PrettyLink.jsx
+++ b/src/common/components/utils/PrettyLink.jsx
@@ -17,8 +17,6 @@ export default class PrettyLink extends Component {
             middle = '',
             end = '';
 
-        // console.log(text, searchText, matchIndex);
-
         if (searchText.length > 0 && matchIndex > -1) {
             start = text.substring(0, matchIndex);
             middle = text.substring(matchIndex, matchIndex + searchText.length);

--- a/src/common/containers/App.jsx
+++ b/src/common/containers/App.jsx
@@ -18,7 +18,8 @@ const mapStateToProps = (state) => {
     }
 
     return {
-        themeColor
+        themeColor,
+        siteAdmin: state.user.user.siteAdmin
     };
 };
 

--- a/src/common/containers/content/pages/StatusPage.jsx
+++ b/src/common/containers/content/pages/StatusPage.jsx
@@ -1,0 +1,26 @@
+/**
+ * StatusPage container
+ * @author pmeijer / https://github.com/patrickkerrypei
+ */
+
+// Libraries
+import { connect } from 'react-redux';
+// Self-defined
+import StatusPage from '../../../components/content/pages/StatusPage';
+
+const mapStateToProps = (state) => {
+    const { basePath } = state;
+    const { user } = state.user;
+    const { users } = state.users;
+    let enabledUsers = users.filter((user) => {
+        return !user.disabled;
+    });
+
+    return {
+        basePath,
+        user,
+        users: enabledUsers
+    };
+};
+
+export default connect(mapStateToProps)(StatusPage);

--- a/src/common/containers/content/pages/StatusPage.jsx
+++ b/src/common/containers/content/pages/StatusPage.jsx
@@ -1,6 +1,6 @@
 /**
  * StatusPage container
- * @author pmeijer / https://github.com/patrickkerrypei
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 // Libraries

--- a/src/server/usermanagement.js
+++ b/src/server/usermanagement.js
@@ -78,7 +78,8 @@ function initialize(middlewareOpts) {
         '/projects', /\/projects\/\w+$/, /\/projects\/\w+\/\w+$/,
         '/organizations', /\/organizations\/\w+$/,
         '/users', /\/users\/\w+$/,
-        '/newuser'
+        '/newuser',
+        '/status'
     ];
 
     router.get(ROUTES, ensureAuthenticated, function(req, res) {


### PR DESCRIPTION
This PR adds the Server status page for site-admin displaying the raw data at `/api/status` with auto-refresh option. The decoration of this page could need some touch-up but the main info is at least there for now.
