### PR TITLE
Fix reload in profile/profile route. Fixes #93

### DIFF
--- a/src/common/components/content/widgets/ProfileBox.jsx
+++ b/src/common/components/content/widgets/ProfileBox.jsx
@@ -376,7 +376,7 @@ export default class ProfileBox extends Component {
     render() {
         const {editable, user, config, isCurrentUser, currentUser} = this.props;
         let isGuest = user._id === config.authentication.guestAccount,
-            nbrOfOwnedProjects = Object.keys(user.projects)
+            nbrOfOwnedProjects = Object.keys(user.projects || {})
                 .filter(projectId => projectId.split('+')[0] === user._id)
                 .length;
 


### PR DESCRIPTION
#93 is caused because of `undefined` being passed to the function `Object.keys` when the user is not fully fetched. The solution should be to optionally pass an empty object to the function. 
https://github.com/webgme/user-management-page/blob/7d5691679c0b7c05474c41c624fbb1bea63f6c79/src/common/components/content/widgets/ProfileBox.jsx#L379